### PR TITLE
Eval, rename refactoring fix

### DIFF
--- a/examples/binary.eval.txt
+++ b/examples/binary.eval.txt
@@ -17,7 +17,7 @@ Running tests for Eval
   "x_1_10":vbool(true),
   "x_1_3":vbool(false)
 )
-[INPUT] x_1_53 = true
+[INPUT] x_1_3 = true
 (
   "x_1_5":vbool(true),
   "answer_2_3":vint(2),

--- a/examples/binary.eval.txt
+++ b/examples/binary.eval.txt
@@ -1,0 +1,46 @@
+Running tests for Eval
+| testing 0/1 
+[INPUT] x_1_10 = true
+(
+  "x_1_5":vbool(false),
+  "x_7_8":vbool(false),
+  "x_8_9":vbool(false),
+  "x_1_10":vbool(true),
+  "x_5_7":vbool(false),
+  "answer_9_10":vint(9)
+)
+[INPUT] x_1_5 = true
+(
+  "x_1_5":vbool(true),
+  "x_3_4":vbool(false),
+  "answer_4_5":vint(4),
+  "x_1_10":vbool(true),
+  "x_1_3":vbool(false)
+)
+[INPUT] x_1_53 = true
+(
+  "x_1_5":vbool(true),
+  "answer_2_3":vint(2),
+  "x_1_10":vbool(true),
+  "x_1_2":vbool(false),
+  "x_1_3":vbool(true)
+)
+[INPUT] x_1_2 = true
+(
+  "x_1_5":vbool(true),
+  "answer_1_2":vint(1),
+  "x_1_10":vbool(true),
+  "x_1_2":vbool(true),
+  "x_1_3":vbool(true)
+)
+[INPUT] x_1_5 = false
+(
+  "x_1_5":vbool(false),
+  "x_7_8":vbool(false),
+  "x_8_9":vbool(false),
+  "x_1_10":vbool(true),
+  "x_5_7":vbool(false),
+  "answer_9_10":vint(9)
+)
+Test report for Evals                                                       
+        all 1/1 tests succeeded

--- a/src/Compile.rsc
+++ b/src/Compile.rsc
@@ -149,7 +149,7 @@ str expr2js(AExpr e) {
       return "<integer>";
 
     case lit(str string):
-      return string;
+      return "\"" + string + "\"";
   }
 }
 

--- a/src/Eval.rsc
+++ b/src/Eval.rsc
@@ -149,7 +149,7 @@ test bool binary() {
 	println("[INPUT] x_1_5 = true");
 	venv = pprintEval(ast, input("x_1_5", vbool(true)), venv);
 
-	println("[INPUT] x_1_53 = true");
+	println("[INPUT] x_1_3 = true");
 	venv = pprintEval(ast, input("x_1_3", vbool(true)), venv);
 
 	println("[INPUT] x_1_2 = true");

--- a/src/Eval.rsc
+++ b/src/Eval.rsc
@@ -3,6 +3,12 @@ module Eval
 import AST;
 import Resolve;
 
+// Needed to run the test at the EOF
+import Syntax;
+import ParseTree;
+import CST2AST;
+import IO;
+
 /*
  * Implement big-step semantics for QL
  */
@@ -53,15 +59,29 @@ VEnv evalOnce(AForm f, Input inp, VEnv venv) {
 VEnv eval(AQuestion q, Input inp, VEnv venv) {
   // evaluate conditions for branching,
   // evaluate inp and computed questions to return updated VEnv
-  switch(q) {
-    case question(str label, AId id, AType \type): venv(id, inp);
-    case question(str label, AId id, AType \type, AExpr expr): venv(id, eval(expr, venv));
-    case \if(AExpr condition, list[AQuestion] questions): 
-      if (eval(condition, venv)) {
-        for (q <- questions) {
+  switch (q) {
+    case question(str label, AId id, AType \type):
+      if (id.name == inp.question) {
+        venv[id.name] = inp.\value;
+      }
+    case question(str label, AId id, AType \type, AExpr expr):
+      venv[id.name] = eval(expr, venv);
+    case \if(condition, questions):
+      if (eval(condition, venv).b) {
+        for (AQuestion q <- questions) {
           venv = eval(q, inp, venv);
         }
-      }  
+      }
+    case \if_else(condition, questions, alt_questions):
+      if (eval(condition, venv).b) {
+        for (AQuestion q <- questions) {
+          venv = eval(q, inp, venv);
+        }
+      } else {
+        for (AQuestion q <- alt_questions) {
+          venv = eval(q, inp, venv);
+        }
+      }
   }
   
   return venv; 
@@ -95,4 +115,48 @@ Value eval(AExpr e, VEnv venv) {
 
     default: throw "Unsupported expression <e>";
   }
+}
+
+VEnv pprintEval(AForm f, Input inp, VEnv venv) {
+  venv = eval(f, inp, venv);
+
+  // In order to pretty-print (show only the enabled questions), we:
+  // 1) Prune all unreachable AST branches, using the previously computed full venv
+  // 2) Resolve the definitions in the (new) pruned tree
+  // 3) Filter the venv definitions to those that survived the pruning
+  AForm pruned = top-down visit (f) {
+    case \if_else(condition, qs, alt_qs) => \if(lit(true), qs)
+      when vbool(true) := eval(condition, venv)
+    case \if_else(condition, qs, alt_qs) => \if(lit(true), alt_qs)
+      when vbool(false) := eval(condition, venv)
+    case \if(condition, qs) => \if(lit(false), [])
+      when vbool(false) := eval(condition, venv)
+  };
+  min_venv = (name : venv[name] | name <- venv, <name, loc def> <- defs(pruned));
+  iprintln(min_venv);
+  // We only _print_ the pruned venv, but return the complete one to be able to sequence inputs
+
+  return venv;
+}
+
+// This test demostrates all features of the interpreter: assigning values, evaluating computed questions, and braching.
+test bool binary() {
+	AForm ast = cst2ast(parse(#start[Form], |project://QL/examples/binary.myql|));
+
+	println("\n[INPUT] x_1_10 = true");
+	venv = pprintEval(ast, input("x_1_10", vbool(true)), initialEnv(ast));
+
+	println("[INPUT] x_1_5 = true");
+	venv = pprintEval(ast, input("x_1_5", vbool(true)), venv);
+
+	println("[INPUT] x_1_53 = true");
+	venv = pprintEval(ast, input("x_1_3", vbool(true)), venv);
+
+	println("[INPUT] x_1_2 = true");
+	venv = pprintEval(ast, input("x_1_2", vbool(true)), venv);
+
+	println("[INPUT] x_1_5 = false");
+	venv = pprintEval(ast, input("x_1_5", vbool(false)), venv);
+
+	return true;
 }

--- a/src/Syntax.rsc
+++ b/src/Syntax.rsc
@@ -65,4 +65,4 @@ lexical Int
  | [1-9][0-9]*
  ;
 
-lexical Str = [\"] ![\"]* [\"];
+lexical Str = @Category="StringLiteral" [\"] ![\"]* [\"];

--- a/src/Transform.rsc
+++ b/src/Transform.rsc
@@ -46,20 +46,16 @@ list[AQuestion] flatten(AQuestion q, AExpr accumulator) = [\if(accumulator, [q])
 start[Form] rename(start[Form] f, loc useOrDef, str newName, RefGraph refs) {
   Id new = [Id] newName;
 
+  loc def = useOrDef;
+  if (<useOrDef, loc d> <- refs.useDef) {
+    def = d;
+  }
+
   return visit (f) {
-    case (Expr) `<Id x>` => (Expr) `<Id new>`
-      when
-        (<useOrDef, loc def> <- refs.useDef || def := useOrDef), // assign definition location to `def`
-        use := x@\loc, <use, def> <- refs.useDef // transform if current node is in the uses of `def`
+    case (Id) `<Id x>` => (Id) `<Id new>`
+      when use := x@\loc, <use, def> <- refs.useDef
 
-    case (Question) `<Str label> <Id x> : <Type t>` => (Question) `<Str label> <Id new> : <Type t>`
-      when
-        (<useOrDef, loc def> <- refs.useDef || def := useOrDef),
-        def == x@\loc
-
-    case (Question) `<Str label> <Id x> : <Type t> = <Expr expr>` => (Question) `<Str label> <Id new> : <Type t> = <Expr expr>`
-      when
-        (<useOrDef, loc def> <- refs.useDef || def := useOrDef),
-        def == x@\loc
+    case (Id) `<Id x>` => (Id) `<Id new>`
+      when x@\loc == def
   }
 }


### PR DESCRIPTION
I assumed a pull request with the commits since the version on the demo would be neatest to review.

You also requested a screenshot/console output of a working `Eval`, this is in `examples/binary.eval.txt`. It demonstrates the venv after each value assignment, filtered by enabled questions (i.e. the same as the ones you would see in the HTML/JS).